### PR TITLE
fix card title overflow

### DIFF
--- a/app/views/bounties/_bounty.html.erb
+++ b/app/views/bounties/_bounty.html.erb
@@ -5,7 +5,7 @@
         <%= number_to_currency bounty.amount, precision: 0 %>
       </div>
 
-      <h2 class="m-0"><%= link_to bounty.title, bounty_path(bounty) %></h2>
+      <h2 class="m-0 [overflow-wrap:anywhere]"><%= link_to bounty.title, bounty_path(bounty) %></h2>
       <div class="text-sm">Created by <%= bounty.user.name %></div>
       <%= simple_format truncate(bounty.description.to_plain_text, length: 1000) %>
     </div>

--- a/app/views/users/bounties/_bounty.html.erb
+++ b/app/views/users/bounties/_bounty.html.erb
@@ -7,7 +7,7 @@
     <%= link_to 'Edit this bounty', edit_users_bounty_path(bounty), class: "text-blue-500 no-underline hover:underline" %>
   </div>
 
-  <h2 class="m-0"><%= bounty.title %></h2>
+  <h2 class="m-0 break-words"><%= bounty.title %></h2>
   <div class="text-sm">Created by <%= bounty.user.name %></div>
   <%= simple_format truncate(bounty.description.to_plain_text, length: 1000) %>
 


### PR DESCRIPTION
This PR handles this issue #17 

I used an arbitrary property `overflow-wrap: anywhere;` in `app/views/bounties/_bounty.html.erb` because `overflow-wrap: break-word;` didn't seem to work on `<a>` tags.