### PR TITLE
fix text overflow from card on all bounties and my bounties page for mobile

### DIFF
--- a/app/views/bounties/_bounty.html.erb
+++ b/app/views/bounties/_bounty.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id bounty %>" class="mb-8 bg-white border shadow rounded-md pt-8 px-8">
+<div id="<%= dom_id bounty %>" class="mb-8 bg-white border shadow rounded-md pt-8 px-8 [overflow-wrap:anywhere]">
   <div class="flex justify-between gap-8">
     <div>
       <div class="mb-4 text-2xl font-bold text-green-600">

--- a/app/views/users/bounties/_bounty.html.erb
+++ b/app/views/users/bounties/_bounty.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id bounty %>" class="bg-white mb-8 border shadow rounded-md pt-8 px-8">
+<div id="<%= dom_id bounty %>" class="bg-white mb-8 border shadow rounded-md pt-8 px-8 break-words">
   <div class="flex justify-between">
     <div class="mb-4 text-2xl font-bold text-green-600">
       <%= number_to_currency bounty.amount, precision: 0 %>


### PR DESCRIPTION
# **_Before Fix_**
<ins>All Bounties Page</ins>
<img width="403" alt="image" src="https://user-images.githubusercontent.com/36496890/222356045-4c234a08-763f-4401-b9ae-0c49b9060f96.png">

<ins>My Bounties Page</ins>
<img width="400" alt="image" src="https://user-images.githubusercontent.com/36496890/222356239-abd568c1-1bff-4f3a-acb9-45eee8c75d84.png">

# **_After Fix_**
<ins>All Bounties Page</ins>
<img width="393" alt="image" src="https://user-images.githubusercontent.com/36496890/222356585-814d7134-428f-4c7f-9705-e3bbb800b89d.png">
<ins>My Bounties Page</ins>
<img width="390" alt="image" src="https://user-images.githubusercontent.com/36496890/222356829-8230b701-c86c-4701-9c39-df70b97577af.png">


Issue - https://github.com/excid3/beginnerbounties.com/issues/17
