### PR TITLE
Styles added to Login & SignUp Pages

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,4 +1,5 @@
 <h2>Change your password</h2>
+<% label_css = "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-half" %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,12 +10,12 @@
     <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em><br />
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: label_css %>
   </div>
 
   <div class="field">
     <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: label_css %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-half" %>
   </div>
 
   <div class="actions">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,16 +1,18 @@
 <h2>Sign up</h2>
 
+<% label_css = "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-half" %>
+
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :name %><br />
-    <%= f.text_field :name, placeholder: "", autofocus: true, autocomplete: "name" %>
+    <%= f.text_field :name, placeholder: "", autofocus: true, autocomplete: "name", class: label_css %>
   </div>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, placeholder: "dog@thebountyhunter.com", autocomplete: "email" %>
+    <%= f.email_field :email, placeholder: "dog@thebountyhunter.com", autocomplete: "email", class: label_css %>
   </div>
 
   <div class="field">
@@ -18,15 +20,15 @@
     <% if @minimum_password_length %>
     <em>(<%= @minimum_password_length %> characters minimum)</em>
     <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.password_field :password, autocomplete: "new-password", class: label_css %>
   </div>
 
   <div class="field">
     <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: label_css %>
   </div>
 
-  <div class="actions">
+  <div class="actions rounded-lg py-2 px-3 mt-5 bg-blue-600 text-white inline-block font-medium cursor-pointer">
     <%= f.submit "Sign up" %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,24 +1,26 @@
 <h2>Log in</h2>
 
+<% label_css = "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-half" %>
+
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: label_css %>
   </div>
 
   <div class="field">
     <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.password_field :password, autocomplete: "current-password", class: label_css %>
   </div>
 
   <% if devise_mapping.rememberable? %>
     <div class="field">
-      <%= f.check_box :remember_me %>
+      <%= f.check_box :remember_me, class: "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600" %>
       <%= f.label :remember_me %>
     </div>
   <% end %>
 
-  <div class="actions">
+  <div class="actions rounded-lg py-2 px-3 mt-5 bg-blue-600 text-white inline-block font-medium cursor-pointer">
     <%= f.submit "Log in" %>
   </div>
 <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,13 +1,14 @@
+<% button_css = "rounded-lg py-2 px-3 mt-5 bg-gray-600 text-white inline-block font-medium cursor-pointer" %>
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Log in", new_session_path(resource_name), class: button_css %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Sign up", new_registration_path(resource_name), class: button_css %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "text-sm font-medium text-primary-600 hover:underline dark:text-primary-500" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>


### PR DESCRIPTION
# Adding Styles to Login and SignUp Pages

**_<h3><ins>Before_**
<ins><h4> Login Page
<img width="1328" alt="Screenshot 2023-03-02 at 10 19 19 PM" src="https://user-images.githubusercontent.com/36496890/222501024-663a78ab-1a18-4afa-ab58-b9e12536bc88.png">
<br> 
<ins><h4> Sign Up Page
<img width="1264" alt="Screenshot 2023-03-02 at 10 19 38 PM" src="https://user-images.githubusercontent.com/36496890/222501067-715847d1-fef5-4b66-ac07-915dfbfe5754.png">



**_<h3><ins>After_**
<ins><h4> Login Page
<img width="1272" alt="image" src="https://user-images.githubusercontent.com/36496890/222501957-f8078ad0-6a5e-4807-9245-945dae58752d.png">
<img width="395" alt="image" src="https://user-images.githubusercontent.com/36496890/222501272-87839fb5-9a63-4fc3-8f8c-e4747bf29a71.png">
<br>
<ins><h4> Sign Up Page
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/36496890/222502343-b4548d73-7a8b-4af7-87f4-8369acbc3d2f.png">
<img width="383" alt="image" src="https://user-images.githubusercontent.com/36496890/222502411-495b2611-0c1a-4602-a367-23fc96efd9ea.png">

