### PR TITLE
Add a weekly Newsletter for the latest open Bounties #19

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
 
+gem "letter_opener", group: :development
+
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 
 gem "letter_opener", group: :development
+gem 'whenever', require: false
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "importmap-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
 
-gem "letter_opener", group: :development
 gem 'whenever', require: false
 
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
@@ -62,6 +61,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  gem "letter_opener"
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -232,6 +233,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.7)
@@ -265,6 +268,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  whenever
 
 RUBY VERSION
    ruby 3.2.1p31

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.8.1)
+      launchy (>= 2.2, < 3)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -234,6 +238,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-19
   x86_64-darwin-22
   x86_64-linux
 
@@ -245,6 +250,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  letter_opener
   name_of_person (~> 1.1)
   pagy (~> 6.0)
   pg (~> 1.1)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "no-reply@beginnerbounties.com"
   layout "mailer"
 end

--- a/app/mailers/bounty_mailer.rb
+++ b/app/mailers/bounty_mailer.rb
@@ -1,11 +1,7 @@
 class BountyMailer < ApplicationMailer
-  default from: 'test@example.com',
-          to: -> { User.all.pluck(:email) }
-
-  layout "mailer"
-
   def open_bounty
-    @bounty = Bounty.where(status: "open").last(15)
-    mail( bcc: User.all.pluck(:email), subject: 'Here are the latest open bounties')
+    @user = params[:user]
+    @bounties = params[:bounties]
+    mail(to: @user.email, subject: "Here are the latest open bounties")
   end
 end

--- a/app/mailers/bounty_mailer.rb
+++ b/app/mailers/bounty_mailer.rb
@@ -1,0 +1,11 @@
+class BountyMailer < ApplicationMailer
+  default from: 'test@example.com',
+          to: -> { User.all.pluck(:email) }
+
+  layout "mailer"
+
+  def open_bounty
+    @bounty = Bounty.where(status: "open").last(15)
+    mail( bcc: User.all.pluck(:email), subject: 'Here are the latest open bounties')
+  end
+end

--- a/app/models/bounty.rb
+++ b/app/models/bounty.rb
@@ -5,7 +5,7 @@ class Bounty < ApplicationRecord
   has_rich_text :description
 
   scope :sorted, -> { in_order_of(:status, STATUSES).order(created_at: :desc) }
-  scope :last_fifteen_open_bounties, -> { where(status: "open").last(15) }
+  scope :open, -> { where(status: "open") }
 
   validates :amount, presence: true, numericality: {greater_than: 0, only_integer: true}
   validates :description, presence: true

--- a/app/models/bounty.rb
+++ b/app/models/bounty.rb
@@ -5,6 +5,7 @@ class Bounty < ApplicationRecord
   has_rich_text :description
 
   scope :sorted, -> { in_order_of(:status, STATUSES).order(created_at: :desc) }
+  scope :last_fifteen_open_bounties, -> { where(status: "open").last(15) }
 
   validates :amount, presence: true, numericality: {greater_than: 0, only_integer: true}
   validates :description, presence: true

--- a/app/views/bounty_mailer/open_bounty.html.erb
+++ b/app/views/bounty_mailer/open_bounty.html.erb
@@ -1,15 +1,6 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-  </head>
-  <body>
-    <p><strong>The open bounties for this week:</strong></p>
-
-    <% @bounty.each do |bounty| %>
-      <h3><%= bounty.title %></h3>
-      <p>Amount: <%= bounty.amount %>$</p>
-      <p><%= link_to "View the source code", bounty.url %></p>
-    <% end %>
-  </body>
-</html>
+<p><strong>The open bounties for this week:</strong></p>
+  <% @bounties.each do |bounty| %>
+    <h3><%= bounty.title %></h3>
+    <p>Amount: <%= bounty.amount %>$</p>
+    <p><%= link_to "View the source code", bounty.url %></p>
+  <% end %>

--- a/app/views/bounty_mailer/open_bounty.html.erb
+++ b/app/views/bounty_mailer/open_bounty.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p><strong>The open bounties for this week:</strong></p>
+
+    <% @bounty.each do |bounty| %>
+      <h3><%= bounty.title %></h3>
+      <p>Amount: <%= bounty.amount %>$</p>
+      <p><%= link_to "View the source code", bounty.url %></p>
+    <% end %>
+  </body>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,7 +39,14 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000}
+  #config.action_mailer.smtp_settings = {:address => 'localhost', :port => 1025}
   config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
+  
+  #config.action_mailer.default_options = {from: 'test@example.com'}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,7 +42,6 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000}
-  #config.action_mailer.smtp_settings = {:address => 'localhost', :port => 1025}
   config.action_mailer.perform_caching = false
   config.action_mailer.perform_deliveries = true
   

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every :sunday, at: '17:00 pm' do
+  rake "send_bounty_email"
+end

--- a/lib/tasks/bounty_tasks.rake
+++ b/lib/tasks/bounty_tasks.rake
@@ -2,8 +2,7 @@ desc 'send open bounties email'
 task send_bounty_email: :environment do
   @bounties = Bounty.open.last(15)
   if @bounties.any?
-    @users = User.all
-    @users.each do |user|
+    User.find_each do |user|
       BountyMailer.with(user: user, bounties: @bounties).open_bounty.deliver_later
     end
   end

--- a/lib/tasks/bounty_tasks.rake
+++ b/lib/tasks/bounty_tasks.rake
@@ -1,0 +1,4 @@
+desc 'send open bounties email'
+task send_bounty_email: :environment do
+  BountyMailer.open_bounty.deliver_later
+end

--- a/lib/tasks/bounty_tasks.rake
+++ b/lib/tasks/bounty_tasks.rake
@@ -1,10 +1,10 @@
 desc 'send open bounties email'
 task send_bounty_email: :environment do
-  @bounties = Bounty.where(status: "open").last(15)
+  @bounties = Bounty.last_fifteen_open_bounties
   if @bounties.any?
     @users = User.all
     @users.each do |user|
-      BountyMailer.with(user: user, bounties: @bounties).open_bounty.deliver_now
+      BountyMailer.with(user: user, bounties: @bounties).open_bounty.deliver_later
     end
   end
 end

--- a/lib/tasks/bounty_tasks.rake
+++ b/lib/tasks/bounty_tasks.rake
@@ -1,4 +1,10 @@
 desc 'send open bounties email'
 task send_bounty_email: :environment do
-  BountyMailer.open_bounty.deliver_later
+  @bounties = Bounty.where(status: "open").last(15)
+  if @bounties.any?
+    @users = User.all
+    @users.each do |user|
+      BountyMailer.with(user: user, bounties: @bounties).open_bounty.deliver_now
+    end
+  end
 end

--- a/lib/tasks/bounty_tasks.rake
+++ b/lib/tasks/bounty_tasks.rake
@@ -1,6 +1,6 @@
 desc 'send open bounties email'
 task send_bounty_email: :environment do
-  @bounties = Bounty.last_fifteen_open_bounties
+  @bounties = Bounty.open.last(15)
   if @bounties.any?
     @users = User.all
     @users.each do |user|

--- a/test/fixtures/bounties.yml
+++ b/test/fixtures/bounties.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   user: one
   title: First Bounty

--- a/test/fixtures/bounties.yml
+++ b/test/fixtures/bounties.yml
@@ -2,14 +2,14 @@
 
 one:
   user: one
-  title: MyString
-  url: MyString
-  amount: MyString
-  status: MyString
+  title: First Bounty
+  url: http://www.google.com/
+  amount: 10
+  status: open
 
 two:
-  user: two
-  title: MyString
-  url: MyString
-  amount: MyString
-  status: MyString
+  user: one
+  title: Second Bounty
+  url: http://www.firefox.com/
+  amount: 32
+  status: assigned

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,3 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one:
   email: first@example.com
   first_name: first

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,14 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one:
+  email: first@example.com
+  first_name: first
+  last_name: Last
+  encrypted_password: foobar
+
+two: 
+  email: second@example.com
+  first_name: second
+  last_name: Doe
+  encrypted_password: foo

--- a/test/mailers/bounty_mailer_test.rb
+++ b/test/mailers/bounty_mailer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BountyMailerTest < ActionMailer::TestCase
+  def open_bounty
+    BountyMailer.with(user: User.first).open_bounty
+  end
+end

--- a/test/mailers/bounty_mailer_test.rb
+++ b/test/mailers/bounty_mailer_test.rb
@@ -1,7 +1,17 @@
 require "test_helper"
 
 class BountyMailerTest < ActionMailer::TestCase
-  def open_bounty
-    BountyMailer.with(user: User.first).open_bounty
+  def setup
+    @user = users(:one)
+    @bounties = [bounties(:one)]
+  end
+
+  test "bounty email" do
+    mail = BountyMailer.with(user: @user, bounties: @bounties).open_bounty
+    assert_equal "first@example.com", @user.email
+    assert_equal "Here are the latest open bounties", mail.subject
+    assert_equal ["first@example.com"], mail.to  
+    assert_equal ["no-reply@beginnerbounties.com"], mail.from
+    assert_match bounties.first.title, mail.body.encoded
   end
 end

--- a/test/mailers/previews/bounty_mailer_preview.rb
+++ b/test/mailers/previews/bounty_mailer_preview.rb
@@ -1,4 +1,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/bounty_mailer
 class BountyMailerPreview < ActionMailer::Preview
-
+  def open_bounty
+    BountyMailer.with(user: User.first,
+                      bounties: Bounty.where(status: "open").last(15)).open_bounty
+  end
 end

--- a/test/mailers/previews/bounty_mailer_preview.rb
+++ b/test/mailers/previews/bounty_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/bounty_mailer
+class BountyMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
Hello, my name is George, I worked on issue #19  and added a weekly newsletter for the latest 15 open bounties.
I used the letter-opener gem and whenever gem for the scheduled emails to all registered users.

Now is scheduled the newsletter every Sunday at 17.00. You can change that on the following file

`config/schedule.rb`  .Also by changing the number on the rake bounty task on the 3rd line `Bounty.open.last(15)`, you can change the number of open Bounties.

I added a mailer test and the test is passing all the assertions.

I would like to thank Chris @excid3 and everyone involved in this project.
Last but not least I would like to thank Cody @cnorm35 who opened this issue and helped me throughout the whole process answering all my questions and helping with issues I had along the way. It was a pleasure the whole process!!! 