### PR TITLE
Update bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.2"
+ruby file: ".ruby-version"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4", ">= 7.0.4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,4 +316,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.6
+   2.4.19


### PR DESCRIPTION
## Update bundler version
- Update bundler version to `2.4.19`
- To manually update the ruby version you now only need to specify the version in the `.ruby-version` file.