### PR TITLE
Show only Open Bounties by default

### DIFF
--- a/app/controllers/bounties_controller.rb
+++ b/app/controllers/bounties_controller.rb
@@ -5,6 +5,7 @@ class BountiesController < ApplicationController
 
   # GET /bounties or /bounties.json
   def index
+    params[:filter] = "open" if params[:filter].nil?
     @bounties = Bounty.sorted
     @filter, @bounties = params[:filter], @bounties.filtered(params[:filter]) if Bounty::STATUSES.include?(params[:filter])
     @pagy, @bounties = pagy(@bounties)

--- a/app/views/bounties/index.html.erb
+++ b/app/views/bounties/index.html.erb
@@ -12,8 +12,18 @@
   </nav>
 </div>
 
-<div id="bounties">
-  <%= render @bounties %>
-</div>
+<% if @bounties.present? %>
+  <div id="bounties">
+    <%= render @bounties %>
+  </div>
 
-<%== pagy_nav(@pagy).html_safe %>
+  <%== pagy_nav(@pagy).html_safe %>
+<% else %>
+  <% if @filter == "open" %>
+    <p class="m-8 md:m-12 text-center italic text-lg md:text-xl">
+      There are no open bounties right now.
+      <br>
+      Spread the word that we need people to post new Beginner Bounties!
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/bounties/index.html.erb
+++ b/app/views/bounties/index.html.erb
@@ -5,7 +5,7 @@
 <div class="my-8 flex gap-2 items-center justify-between">
   <h2 class="m-0"><%= (@filter || "All").titleize %> Bounties</h2>
   <nav class="flex gap-2">
-    <%= link_to "All", bounties_path, class: class_names("font-bold" => @filter.blank?) %>
+    <%= link_to "All", bounties_path(filter: "none"), class: class_names("font-bold" => @filter.blank?) %>
     <% Bounty::STATUSES.each do |status| %>
       <%= link_to status.titleize, bounties_path(filter: status), class: class_names("font-bold" => status == @filter) %>
     <% end %>


### PR DESCRIPTION
### This PR resolves these issues:
- #51
- #66 

-----

- [x]  Show `open` Bounties by default in https://github.com/excid3/beginnerbounties.com/commit/5e054c67bc84c73cee35257da6309b21061acb42 by setting `filter` param to `open` only if `filter` is `nil`. 
- [x] We set the `filter` of `none` to the 'All' link to show all the bounties. Since `none` isn't present in the `Bounty::STATUSES` this won't apply any filters in 116ad8d5cd9c3149a69589653de101ef549f8e94.
- [x] Show custom message only if there're **no `open` bounties present** in b7a9d7d5f673abc22a81c603cde691700f85acc5.


![Screenshot from 2024-08-13 15-29-23](https://github.com/user-attachments/assets/10043678-904c-4512-baa3-f55638cc7b9d)
